### PR TITLE
Fix Bugs, Small In-Game Text Rework , Further Code Organization, Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
-  <h1><code>Shavit Tank Controls</code></h1>
+  <h1><code>Shavit Fixed Camera</code></h1>
   <p>
-    <strong>90's-inspired tank controls for shavit's CS:S bhop timer with fixed third-person camera rotation</strong>
+    <strong>90's-inspired fixed camera style for shavit's CS:S bhop timer including camera rotation system and more</strong>
   </p>
 </div>
 
@@ -9,51 +9,49 @@
 
 ## Features
 
-- **Third-person camera** with 4-way rotation (behind/left/front/right)
-- **Automatic binds**: E/Shift keys rotate camera (toggleable)
-- **Manual commands**: If you don't like the default keybinds you can bind `tcleft` / `tcright` to any button you want to rotate the camera
+- **Fixed camera** with 4-way rotation (behind/left/front/right) with diagonal camera angles mode included
+- **Automatic binds**: Shift / E keys are binded automatically to rotate the camera (toggleable)
+- **Manual binds**: If you don't like the default keybinds you can bind `fcleft` / `fcright` to any key you want to rotate the camera
 - **Interactive settings menu**: Change FOV, toggle binds and night vision directly in the menu
-- **Quick commands**: All commands accessible in-game
-- **Shavit integration**: Seamless with shavit-timer system
+- **Shavit integration**: Seamless with shavit's timer
 
 ## Installation
 
 > **⚠️ IMPORTANT NOTICE:**  
-> Add `bash_bypass` to your Tank Controls style specialstring to avoid Bash warnings/bans:
+> Add `bash_bypass` to your Fixed Camera style's specialstrings to avoid Bash warnings:
 > ```
-> "specialstring" "tcontrols; bash_bypass"
+> "specialstring" "fixedcamera; bash_bypass"
 > ```
 
-1. **Compile**: `spcomp -include shavit-style-tankcontrols.sp`
+1. **Compile**: `spcomp -include shavit-style-fixedcamera.sp` (or download the compiled plugin directly from the [releases](https://github.com/NSchrot/shavit-style-fixedcamera/releases) page)
 2. **Install**: Place the compiled `.smx` in `addons/sourcemod/plugins/`
-3. **Configure**: Add your style with `"specialstring" "tcontrols"` in your Shavit config
+3. **Configure**: Add your style with `"specialstring" "fixedcamera"` in your shavit-styles.cfg
 4. **Restart your server**
 
 ## Commands & Controls
 
-| Command         | Key/Usage      | Description                              |
+| Command         | Key/Usage     | Description                              |
 |-----------------|---------------|------------------------------------------|
-| `/tcmenu`       | -             | Open the Tank Controls settings menu     |
-| `/tcsettings`   | -             | Alias for `/tcmenu`                      |
-| `/tcoptions`    | -             | Alias for `/tcmenu`                      |
-| `/tccommands`   | -             | Show all Tank Controls commands     |
-| `/tchelp`       | -             | Alias for `/tccommands`                  |
-| `/tcfov <val>`  | -             | Set camera FOV (80-120)                  |
-| `/tcnvg`        | -             | Toggle night vision                      |
-| `tcright`       | -             | Rotate camera right                      |
-| `tcleft`        | -             | Rotate camera left                       |
-| `toggletckeys`  | -             | Toggle auto-binded rotation on/off       |
+| `/fcmenu`       | -             | Open the Fixed Camera settings menu      |
+| `/fccommands`   | -             | Show all Fixed Camera commands           |
+| `/fchelp`       | -             | Alias for `/fccommands`                  |
+| `/fcdiagonal`   | -             | Toggle diagonal camera angle             |
+| `/fctogglebinds`| -             | Toggle auto-binded rotation On/Off       |
+| `/fcnvg`        | -             | Toggle night vision                      |
+| `/fcfov <val>`  | -             | Set camera FOV (80-120)                  |
+| `fcleft`        | -             | Rotate camera left                       |
+| `fcright`       | -             | Rotate camera right                      |
 | `+speed`        | **Shift**     | Rotate camera left (if enabled)          |
 | `+use`          | **E**         | Rotate camera right (if enabled)         |
 
 
 ## Usage
 
-1. Select **Tank Controls** style in the `!style` menu
+1. Select **Fixed Camera** style in the `!style` menu
 2. Camera switches to third-person automatically
 3. Use **Shift/E** or manual commands to rotate the camera
-4. Use `/tcmenu` for all settings (FOV, binds, night vision, etc.)
-5. Use `/tchelp` for a quick in-game reference of all commands
+4. Use `/fcmenu` for all settings (FOV, binds, night vision, etc)
+5. Use `/fchelp` for a quick in-game reference of all commands
 
 ## Menu System
 
@@ -65,7 +63,7 @@
 
 - **Commands Menu**:  
   - Shows all available commands  
-  - Accessible via `/tchelp` or `/tccommands`
+  - Accessible via `/fchelp` or `/fccommands`
 
 
 ## Configuration Example
@@ -85,9 +83,9 @@ Add to your `shavit-styles.cfg`:
 
 ## ConVars
 
-| ConVar                        | Default       | Description                    |
-|-------------------------------|---------------|--------------------------------|
-| `ss_tankcontrols_specialstring` | `tcontrols` | Special string for style detection |
+| ConVar                          | Default       | Description                        |
+|---------------------------------|---------------|------------------------------------|
+| `ss_fixedcamera_specialstring`  | `fixedcamera` | Special string for style detection |
 
 ## Requirements
 
@@ -100,13 +98,13 @@ Add to your `shavit-styles.cfg`:
 ## Troubleshooting
 
 - **Camera not activating**:  
-  Ensure your style has `"specialstring" "tcontrols"` in the Shavit config.
+  Ensure your style has `"specialstring" "fixedcamera"` in the Shavit config.
 
 - **Keys not working**:  
-  Use `/toggletckeys` or try manual commands (`tcright`, `tcleft`).
+  Use `/fctogglebinds` or try manual commands (`fcright`, `fcleft`).
 
 - **Can't switch weapons**:  
-  This is a limitation of the third-person implementation, which uses the Spectator Camera. Unless the camera system is changed, this can't be fixed.
+  This is a limitation of the third-person implementation, which uses the Spectator Camera. Unless the camera system is somehow changed, this can't be fixed.
 
 
 ---

--- a/shavit-style-fixedcamera.sp
+++ b/shavit-style-fixedcamera.sp
@@ -211,19 +211,22 @@ public void OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 
 public Action OnPlayerRunCmd(int client, int& buttons, int& impulse, float vel[3], float angles[3])
 {
-	if (!IsValidClient(client) || !g_bThirdPersonEnabled[client] || !g_bUseHardcodedKey[client])
+	if (!IsValidClient(client) || !g_bThirdPersonEnabled[client])
 		return Plugin_Continue;
 
-	if (buttons & IN_USE)
+	if (g_bUseHardcodedKey[client])
 	{
-		if (!(g_iLastButtons[client] & IN_USE))
-			Command_RotateCameraRight(client, 0);
-	}
-	
-	if (buttons & IN_SPEED)
-	{
-		if (!(g_iLastButtons[client] & IN_SPEED))
-			Command_RotateCameraLeft(client, 0);
+		if (buttons & IN_USE)
+		{
+			if (!(g_iLastButtons[client] & IN_USE))
+				Command_RotateCameraRight(client, 0);
+		}
+		
+		if (buttons & IN_SPEED)
+		{
+			if (!(g_iLastButtons[client] & IN_SPEED))
+				Command_RotateCameraLeft(client, 0);
+		}
 	}
 
 	g_iLastButtons[client] = buttons;


### PR DESCRIPTION
## Fixes
- Fix bug where if the nightvision was enabled and the player came back from spec it would not re-enable automatically
- Fix bug where movement key block logic would be skipped if not using the hardcoded Shift / E binds for camera rotation
- Slight increase to diagonal camera command timer from 0.03 to 0.034 to prevent vertical camera position logic skip

## Misc
- Small help menu text change
- Further Code Organization (commands is now placed before timers and functions)

## Readme
- Update readme file, replacing the old style name with the new one, and also include new commands

## Known Issues
- Vertical camera position logic is sometimes skipped if using manual binds (fcleft / fcright), this goes the same for the diagonal camera angle command, which the timer was slightly increased for this command from 0.03 to 0.034, to help prevent this issue.